### PR TITLE
Allow this module to be loaded in node without erroring

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,13 @@ var inherits = require('inherits')
 var shimvis = true
 var change = null
 var hidden = null
+var doc = typeof document !== 'undefined'
 
 module.exports = Visibility
 
+if (!doc) {
+	// Just skips the other stuff
+} else
 if (typeof document.hidden !== 'undefined') {
   hidden = 'hidden'
   change = 'visibilitychange'
@@ -31,6 +35,8 @@ function Visibility() {
 
   EventEmitter.call(this)
   this.supported = !!hidden
+
+  if(!doc) return this
 
   if (this.supported) {
     document.addEventListener(change, function() {


### PR DESCRIPTION
By adding these checks, this module will load in node without errors.  We are using this in _cringe_ isomorphic app, and this got required in on accident.  This is one way to handle it, the other is to use the `browser` and `main` fields of package.json and mocking out the api.  If you think that is a better way then let me know and I can re-submit this.
